### PR TITLE
[Fix] for some reason no audio device  if you set format channel to 1

### DIFF
--- a/mainWindow.cpp
+++ b/mainWindow.cpp
@@ -119,7 +119,7 @@ MainWindow::MainWindow(QWidget *parent)
     bufferSize = 8192*2;
 
     m_format.setSampleRate(44100);
-    m_format.setChannelCount(1);
+    m_format.setChannelCount(2);
     m_format.setSampleSize(16);
     m_format.setCodec("audio/pcm");
     m_format.setByteOrder(QAudioFormat::LittleEndian);
@@ -131,6 +131,7 @@ MainWindow::MainWindow(QWidget *parent)
         m_format = info.nearestFormat(m_format);
     }
     m_device = QAudioDeviceInfo::defaultOutputDevice();
+    qWarning() << "Default device :" << m_device.deviceName();
     m_buffer = QByteArray(bufferSize*2, 0);
 
     m_audioOutput = new QAudioOutput(m_device, m_format, this);

--- a/outputQt.cpp
+++ b/outputQt.cpp
@@ -138,8 +138,9 @@ Generator::addWave(unsigned char note, unsigned char vel) {
     wav.state_age = 0;
     wav.age      = 0;
     wav.env = defaultEnv;
-
+    mutex.lock();
     waveList.push_back(wav);
+    mutex.unlock();
 }
 
 qint64
@@ -228,6 +229,7 @@ Generator::generateData(qint64 len) {
                    filteredData = QVector<qreal>(numSamples, 0);
 
     // All samples for each active note in waveList are synthesized separately.
+    mutex.lock();
     QMutableListIterator<Wave> i(waveList);
 
     while (i.hasNext()) {
@@ -305,7 +307,8 @@ Generator::generateData(qint64 len) {
             i.setValue(wav);
         }
     }
-
+    mutex.unlock();
+    
     for (unsigned int sample = 0; sample < numSamples; sample++) {
         convBuffer[convBuffer_ind] = synthData[sample];
         filteredData[sample] = 0;
@@ -323,7 +326,7 @@ Generator::generateData(qint64 len) {
         delayBuffer[delayBuffer_ind] = filteredData[sample];
         delayBuffer_ind = (delayBuffer_ind + 1) % delayBuffer_size;
 
-        // Primitive Reverb algorith.
+        // Primitive Reverb algorithm.
         if (rev.active) {
             qreal reverb = 0;
             unsigned int ind;
@@ -452,3 +455,4 @@ Generator::setReverb(Reverb &_rev) {
     qDebug() << "setReverb";
     rev = _rev;
 }
+

--- a/outputQt.h
+++ b/outputQt.h
@@ -25,6 +25,7 @@
 
 #include <QList>
 #include <QMutableListIterator>
+#include <QMutex>
 
 #include "linearSynthesis.h"
 #include "ADSRenvelope.h"
@@ -124,6 +125,7 @@ private:
 
     qreal fftTimer;
 
+    QMutex mutex;
 #ifdef USE_FFTW
     fftw_complex *fftwIn, *fftwOut;
     fftw_plan     fftwPlan;
@@ -134,3 +136,4 @@ private:
 };
 
 #endif // OUTPUTQT_H
+


### PR DESCRIPTION

without

```
    m_format.setChannelCount(2);
```

the default audio device is not found. This is at least true with Qt 5.15 on linux.